### PR TITLE
correction nom du module dans bindings/castem/modules/CMakeLists.txt

### DIFF
--- a/bindings/castem/modules/CMakeLists.txt
+++ b/bindings/castem/modules/CMakeLists.txt
@@ -3,5 +3,5 @@ macro(castem_hho_fortran_module file)
     DESTINATION "include")
 endmacro(castem_hho_fortran_module)
 
-castem_hho_fortran_module(castem_fortran_utilities.mod)
+castem_hho_fortran_module(castem_hho_fortran_utilities.mod)
 castem_hho_fortran_module(castem_hho.mod)


### PR DESCRIPTION
Bonjour,

J'ai compris pourquoi le "make install" échoue au niveau du fichier "bindings/castem/modules/CMakeLists.txt" :

Il faut remplacer la ligne "castem_hho_fortran_module(castem_fortran_utilities.mod)" par "castem_hho_fortran_module(castem_hho_fortran_utilities.mod)" dans ce fichier.

En effet, dans le répertoire "bindings/castem/src/", le fichier source s'appelle "castem_hho_fortran_utilities.f95" et non "castem_fortran_utilities.f95".

David: J'ai créé une "pull request" sur GitHub ;)

Thibault